### PR TITLE
Add support for Content-MD5 header.

### DIFF
--- a/nox.js
+++ b/nox.js
@@ -56,6 +56,7 @@ exports.createClient = function(options) {
       date:date,
       resource:auth.canonicalizeResource(path.join('/', options.bucket, filename)),
       contentType:headers['Content-Type'],
+      md5:headers['Content-MD5'],
       amazonHeaders:auth.canonicalizeHeaders(headers)
     });
 

--- a/test-noxmox.js
+++ b/test-noxmox.js
@@ -8,6 +8,7 @@
 // The JSON file shall contain an object with the aws key, secret and bucketname.
 
 var fs = require('fs');
+var crypto = require('crypto');
 var util = require('util');
 
 var nox = require('./nox.js');
@@ -59,7 +60,8 @@ function upload(client, name, buf, callback) {
   console.log('\nFile upload');
   var req = client.put(name, {
     'Content-Type':'text/plain',
-    'Content-Length':buf.length
+    'Content-Length':buf.length,
+    'Content-MD5': crypto.createHash('md5').update(buf).digest('base64')
   });
   req.on('error', function(err) {
     console.log(err.message || err);


### PR DESCRIPTION
I wanted to add the `Content-MD5` header when uploading files, but noticed it wasn't supported by `noxmox`. This commit adds the support.
