### PR TITLE
Fixed open file handle leak

### DIFF
--- a/mox.js
+++ b/mox.js
@@ -61,7 +61,7 @@ function wrapWritableStream(ws) {
   self.destroySoon = function() { self.writable = false; ws.destroySoon(); };
 
   ws.on('drain', function() { self.emit('drain'); });
-  ws.on('error', function(err) { self.writeable = false; });
+  ws.on('error', function(err) { self.writable = false; });
   ws.on('close', function() { self.emit('close'); });
   ws.on('pipe', function(src) { self.emit('pipe', src); });
 

--- a/mox.js
+++ b/mox.js
@@ -56,7 +56,7 @@ function wrapWritableStream(ws) {
 
   self.writable = true;
   self.write = function(chunk, enc) { return ws.write(chunk, enc); };
-  self.end = function(chunk, enc) { self.writable = false; if (chunk) self.write(chunk, enc); };
+  self.end = function(chunk, enc) { self.writable = false; if (chunk) self.write(chunk, enc); ws.end() };
   self.destroy = function() { self.writable = false; ws.destroy(); }
   self.destroySoon = function() { self.writable = false; ws.destroySoon(); };
 


### PR DESCRIPTION
Was periodically getting an EMFILE error.

Turns out it was because mox was not closing the the underlying writeStream when the wrapper's end method was being called.
