### PR TITLE
client.url fix, as well as win32 tmp file location fix

### DIFF
--- a/mox.js
+++ b/mox.js
@@ -82,7 +82,11 @@ exports.createClient = function createClient(options) {
   }
 
   if (!options.prefix) {
-    options.prefix = '/tmp/mox';
+    if (process.platform === "win32") {
+      options.prefix = process.env["TEMP"] + "/mox";
+    } else {
+      options.prefix = '/tmp/mox';
+    }
   }
 
   // create storage dir, if it doesn't exists
@@ -303,12 +307,12 @@ exports.createClient = function createClient(options) {
   };
 
   client.url =
-  client.http = function(filename){
-    return (filename)
+  client.http = function(filename) {
+    return (options.domain || '').replace("https:","http:") + filename;
   };
 
   client.https = function(filename){
-    return (filename)
+    return (options.domain || '').replace("http:", "https:") + filename;
   };
 
   return client;


### PR DESCRIPTION
This fixes two things - the first fixes a hard error caused by mox.js trying to write files in a protected area on windows. The patch makes it write safely to the user's temp directory. The second fix adds an optional domain to the options object passed to `createClient` so that client.url(...) can return a fully qualified URL. Without a domain property, the `url`, `http` and `https` functions do exactly the same as before. Having the fully qualified URL makes it easier to use noxmox alongside libraries such as `knox`.
