### PR TITLE
Made mox create and read from a directory structure if a filename contains a path

### DIFF
--- a/mox.js
+++ b/mox.js
@@ -116,17 +116,10 @@ exports.createClient = function createClient(options) {
       filePath.shift();
     }
 
-    // Encode each part
-    filePath = filePath.map(function(section) {
-      // The new naming scheme:
-      // encode filePath using the fixedEncodeURIComponent from
-      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
-      return encodeURIComponent(section)
+    var fileName = filePath.pop();
+    fileName = encodeURIComponent(fileName)
         .replace(/[!'()]/g, escape)
         .replace(/\*/g, "%2A");
-    });
-
-    var fileName = filePath.pop();
 
     // Ensure the path exists, then recombine
     var tmp = '/';

--- a/test-noxmox.js
+++ b/test-noxmox.js
@@ -82,7 +82,7 @@ function runTests(data) {
 
 
 function test(client, callback) {
-  var name = 'test/noxmox.txt';
+  var name = 'test/foo/blaz/noxmox.txt';
   t1();
   function t1() {
     var buf = new Buffer('Testing the noxmox lib.');


### PR DESCRIPTION
This patch makes mox create a folder structure during its writes of files. The goal was to make serving those files with a local webserver match what S3 does, namely respecting folder divisions. With this patch, files created using `client.put('/path/to/file.txt', headers);` will change the directory listing from:

```
-->/
---->/bucket
------>/bucket/%2Fpath%2Fto%2Ffile.txt
```

to: 

```
--> /
---->/bucket
------>/bucket/path
-------->/bucket/path/to
---------->/bucket/path/to/file.txt
```
